### PR TITLE
Support PHP 8.4

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['8.2', '8.3']
+        php: ['8.2', '8.3', '8.4']
 
     steps:
       - name: Set up PHP

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.idea
 /vendor
 composer.lock
+.tool-versions

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ https://github.com/laravel/prompts/assets/19181121/03c6f46d-a19d-4de0-af71-66b65
 
 By using `fileselector()`, you can input the file path `quickly` and `accurately`.
 
+This feature has been included into [Community Prompts](https://github.com/artisan-build/community-prompts).
+
+## Requirements
+
+- PHP 8.2 or later
+- [Composer](https://getcomposer.org/)
+
 ## Installation
 
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,13 @@
         }
     },
     "require": {
-        "php": "^8.1",
-        "laravel/prompts": "^0.1.23"
+        "php": "^8.2",
+        "laravel/prompts": "^0.3"
     },
     "require-dev": {
+        "illuminate/collections": "^10.0|^11.0",
         "phpstan/phpstan": "^1.11",
-        "pestphp/pest": "^2.3",
+        "pestphp/pest": "^2.3|^3.4",
         "mockery/mockery": "^1.5",
         "phpstan/phpstan-mockery": "^1.1"
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true" backupStaticProperties="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true" backupStaticProperties="true" failOnWarning="true">
   <testsuites>
     <testsuite name="Test Suite">
       <directory suffix="Test.php">./tests</directory>

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Composer\InstalledVersions;
+
 /*
 |--------------------------------------------------------------------------
 | Test Case
@@ -39,7 +41,7 @@ expect()->extend('toBeOne', function () {
 |
 */
 
-function something()
+function depends_on_collection(): bool
 {
-    // ..
+    return InstalledVersions::isInstalled('illuminate/collections');
 }


### PR DESCRIPTION
This PR:

- Supports PHP 8.4
- Updates dependencies (https://github.com/laravel/prompts/pull/167)
- Updates phpunit.xml (https://github.com/laravel/prompts/pull/164)
- Updates `tests/Pest.php` (https://github.com/laravel/prompts/pull/168)
- Updates README